### PR TITLE
Feature/upgrade fider to v19.1

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,59 @@
+#####################
+### Server Build Step
+#####################
+FROM golang:1.16.6-buster AS server-builder 
+
+ARG buildnumber=local
+
+RUN mkdir /server
+WORKDIR /server
+
+COPY . .
+RUN BUILDNUMBER=${buildnumber} GOOS=linux GOARCH=amd64 make build-server
+
+#################
+### UI Build Step
+#################
+FROM node:16-buster AS ui-builder 
+
+RUN mkdir /ui
+WORKDIR /ui
+
+COPY . .
+RUN npm ci
+RUN make build-ssr
+RUN make build-ui
+
+################
+### Runtime Step
+################
+FROM debian:buster-slim
+
+RUN apt-get update
+RUN apt-get install -y ca-certificates wget
+
+# 'dockerize -wait'
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY --from=server-builder /server/migrations /app/migrations
+COPY --from=server-builder /server/views /app/views
+COPY --from=server-builder /server/locale /app/locale
+COPY --from=server-builder /server/LICENSE /app
+COPY --from=server-builder /server/fider /app
+
+COPY --from=ui-builder /ui/favicon.png /app
+COPY --from=ui-builder /ui/dist /app/dist
+COPY --from=ui-builder /ui/robots.txt /app
+COPY --from=ui-builder /ui/ssr.js /app
+
+EXPOSE 3000
+
+HEALTHCHECK --timeout=5s CMD ./fider ping
+
+CMD ./fider migrate && ./fider

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -9,7 +9,8 @@ RUN npm ci
 RUN node -v 
 RUN npm -v 
 # Override SMTTP TLS
-RUN sed -i -e '/auth :=/d' -e 's/servername, auth, email/servername, email/g' \
+RUN sed -i -e '/auth :=/d' \
+  -e 's/servername, smtpConfig.EnableStartTLS, auth, email/servername, smtpConfig.EnableStartTLS, email/g' \
   -e 's/, a gosmtp.Auth, from/, from/g' -e '/if a != nil {/,+7d' \
   -e 's/Config{ServerName: host}/Config{InsecureSkipVerify: true, ServerName: host}/g' \
   app/services/email/smtp/smtp.go && \

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,35 +1,57 @@
-# Build Step
-FROM getfider/githubci:0.0.2 AS builder
+#####################
+### Server Build Step
+#####################
+FROM golang:1.16.6-buster AS server-builder 
 
-RUN mkdir /app
-WORKDIR /app
+ARG buildnumber=local
 
-COPY fider .
+RUN mkdir /server
+WORKDIR /server
+
+COPY . .
+RUN BUILDNUMBER=${buildnumber} GOOS=linux GOARCH=amd64 make build-server
+
+#################
+### UI Build Step
+#################
+FROM node:16-buster AS ui-builder 
+
+RUN mkdir /ui
+WORKDIR /ui
+
+COPY . .
 RUN npm ci
-RUN node -v 
-RUN npm -v 
+RUN make build-ssr
+RUN make build-ui
+
 # Override SMTTP TLS
 RUN sed -i -e '/auth :=/d' \
   -e 's/servername, smtpConfig.EnableStartTLS, auth, email/servername, smtpConfig.EnableStartTLS, email/g' \
   -e 's/, a gosmtp.Auth, from/, from/g' -e '/if a != nil {/,+7d' \
   -e 's/Config{ServerName: host}/Config{InsecureSkipVerify: true, ServerName: host}/g' \
-  app/services/email/smtp/smtp.go && \
-  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 mage build
+  app/services/email/smtp/smtp.go 
 
-# Runtime Step
-FROM alpine:3.10
-RUN apk update && apk add ca-certificates
+################
+### Runtime Step
+################
+FROM debian:buster-slim
+
+RUN apt-get update
+RUN apt-get install -y ca-certificates
 
 RUN mkdir /app
 WORKDIR /app
 
-COPY --from=builder /app/favicon.png /app
-COPY --from=builder /app/migrations /app/migrations
-COPY --from=builder /app/views /app/views
-COPY --from=builder /app/dist /app/dist
-COPY --from=builder /app/LICENSE /app
-COPY --from=builder /app/robots.txt /app
-COPY --from=builder /app/fider /app
+COPY --from=server-builder /server/migrations /app/migrations
+COPY --from=server-builder /server/views /app/views
+COPY --from=server-builder /server/locale /app/locale
+COPY --from=server-builder /server/LICENSE /app
+COPY --from=server-builder /server/fider /app
+
+COPY --from=ui-builder /ui/favicon.png /app
+COPY --from=ui-builder /ui/dist /app/dist
+COPY --from=ui-builder /ui/robots.txt /app
+COPY --from=ui-builder /ui/ssr.js /app
 
 EXPOSE 3000
 

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -8,7 +8,7 @@ ARG buildnumber=local
 RUN mkdir /server
 WORKDIR /server
 
-COPY . .
+COPY fider .
 RUN BUILDNUMBER=${buildnumber} GOOS=linux GOARCH=amd64 make build-server
 
 #################
@@ -19,7 +19,7 @@ FROM node:16-buster AS ui-builder
 RUN mkdir /ui
 WORKDIR /ui
 
-COPY . .
+COPY fider .
 RUN npm ci
 RUN make build-ssr
 RUN make build-ui

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
       - [Log into the Fider app](#log-into-the-fider-app-1)
   - [Integration with Platform SSO KeyCloak Shared instance](#integration-with-platform-sso-keycloak-shared-instance)
   - [FAQ](#faq)
+    - [Upgrade Fider submodule](#upgrade-fider-submodule)
   - [TODO](#todo)
     - [Done](#done)
   - [SMTPS Issue](#smtps-issue)
@@ -41,11 +42,8 @@ BC Gov's [SMTP](https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol) con
 
 ## Prerequisites
 
-Network Security Policy is in place:
+Network Security Policies are in place; Aporeto is no longer supported on OCP, so see https://developer.gov.bc.ca/Openshift-Useful-Pro-Tips 
 
-```bash
-oc -n 599f0a-tools process -f https://raw.githubusercontent.com/BCDevOps/platform-services/master/security/aporeto/docs/sample/quickstart-nsp.yaml NAMESPACE=599f0a-tools | oc -n 599f0a-tools create -f -
-```
 
 For builds:
 
@@ -458,11 +456,51 @@ git submodule add https://github.com/getfider/fider
   git submodule update --remote
 ```
 
+### Upgrade Fider submodule
+
+This is an example when updating from v19.0 to v19.1
+
+First check status of the submodle
+```
+~/p/nrm-feedback ❯❯❯ git submodule  status  
+-74ac88ed1f6dfac1a3adfb93eb9c8c325f0018a8 fider
+
+~/p/nrm-feedback ❯❯❯ more .gitmodules
+[submodule "fider"]
+        path = fider
+        url = https://github.com/getfider/fider
+```
+
+Update, although you don't really need the `--init`  anymore
+
+```
+~/p/nrm-feedback ❯❯❯ git submodule update --init --recursive 
+Submodule 'fider' (https://github.com/getfider/fider) registered for path 'fider'
+Cloning into '/Users/garywong/proj/nrm-feedback/fider'...
+Submodule path 'fider': checked out '74ac88ed1f6dfac1a3adfb93eb9c8c325f0018a8'
+
+~/p/nrm-feedback ❯❯❯ cd fider     
+~/p/n/fider ❯❯❯ git status 
+HEAD detached at 74ac88ed
+nothing to commit, working tree clean
+
+~/p/n/fider ❯❯❯ git checkout v0.19.1 
+Previous HEAD position was 74ac88ed enhancement: Patch on Avatar.tsx to activate name tooltip via title attribute (#842)
+HEAD is now at c962c411 chore: update version to 0.19.1
+
+~/p/n/fider ❯❯❯ git status     
+HEAD detached at v0.19.1
+nothing to commit, working tree clean
+```
+
+Although the `git checkout` can be against latest, we're choosing a specific tag. Note that git submodules won't be updated auotmatically unless the `git checkout` is run, and the parent rep commited.
+
 ## TODO
 
 - document KeyCloak integration
-- test out application upgrade (e.g. Fider updates their version)
 - check for image triggers which force a reploy (image tags.. latest -> v0.19.0)
+
+
 
 ### Done
 
@@ -473,6 +511,7 @@ git submodule add https://github.com/getfider/fider
 - health checks for each of the database container
 - convert ci/openshift/_.json to _.yaml
 - tested DB backup/restore and transfer with [Backup-Containers](https://github.com/BCDevOps/backup-container)
+- tested `git submodule update`
 
 ## SMTPS Issue
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
       - [Log into the Fider app](#log-into-the-fider-app-1)
   - [Integration with Platform SSO KeyCloak Shared instance](#integration-with-platform-sso-keycloak-shared-instance)
   - [FAQ](#faq)
-    - [Upgrade Fider submodule](#upgrade-fider-submodule)
+    - [Upgrade Fider Git submodule](#upgrade-fider-git-submodule)
   - [TODO](#todo)
     - [Done](#done)
   - [SMTPS Issue](#smtps-issue)
@@ -291,7 +291,7 @@ export FEEDBACK=eao
 
 After thirty seconds, the database pod should be up.
 
-> oc -n ${PROJECT} rsh $(oc -n ${PROJECT} get pods | grep -v -e "${FEEDBACK}fider-postgresql-.-deploy" | grep Running | grep fider | awk '{print $1}')
+> oc -n ${PROJECT} rsh $(oc -n ${PROJECT} get pods | grep -v -e "${FEEDBACK}fider-postgresql-.-deploy" | grep Running | grep ${FEEDBACK}fider | awk '{print $1}')
 
 
 ```bash
@@ -308,7 +308,9 @@ Type `exit` to exit the remote shell.
 
 ### Application Deployment
 
-> oc -n ${PROJECT} new-app --file=./ci/openshift/fider-bcgov.dc.yaml -p FEEDBACK_NAME=${FEEDBACK}fider -p IS_NAMESPACE=\${TOOLS} -p EMAIL_SMTP_USERNAME=Daffy.Duck@gov.bc.ca
+```
+oc -n ${PROJECT} new-app --file=./ci/openshift/fider-bcgov.dc.yaml -p FEEDBACK_NAME=${FEEDBACK}fider -p IS_NAMESPACE=${TOOLS} -p EMAIL_SMTP_USERNAME=Daffy.Duck@gov.bc.ca
+```
 
 ```bash
 --> Deploying template "599f0a-dev/nrmf-feedback-dc" for "./ci/openshift/fider-bcgov.dc.yaml" to project 599f0a-dev
@@ -456,7 +458,7 @@ git submodule add https://github.com/getfider/fider
   git submodule update --remote
 ```
 
-### Upgrade Fider submodule
+### Upgrade Fider Git submodule
 
 This is an example when updating from v19.0 to v19.1
 
@@ -471,7 +473,7 @@ First check status of the submodle
         url = https://github.com/getfider/fider
 ```
 
-Update, although you don't really need the `--init`  anymore
+Update, although we don't really need the `--init`  anymore, after the initial time.
 
 ```
 ~/p/nrm-feedback ❯❯❯ git submodule update --init --recursive 
@@ -495,11 +497,21 @@ nothing to commit, working tree clean
 
 Although the `git checkout` can be against latest, we're choosing a specific tag. Note that git submodules won't be updated auotmatically unless the `git checkout` is run, and the parent rep commited.
 
+NOTE: Fider often updates the `fider\Dockerfile` so be sure to integrate the changes to `.\Dockerfile.openshift` and `.\Dockerfile.dev` 
+
+For the former, be sure to change:
+```
+COPY . .
+```
+to
+```
+COPY fider .
+```
+
 ## TODO
 
 - document KeyCloak integration
 - check for image triggers which force a reploy (image tags.. latest -> v0.19.0)
-
 
 
 ### Done

--- a/ci/openshift/fider-bcgov.bc.yaml
+++ b/ci/openshift/fider-bcgov.bc.yaml
@@ -47,7 +47,7 @@ objects:
           from:
             kind: DockerImage
             name: alpine:3.10
-          dockerfilePath: ../Dockerfile.openshift
+          dockerfilePath: Dockerfile.openshift
       output:
         to:
           kind: ImageStreamTag

--- a/ci/openshift/fider-bcgov.bc.yaml
+++ b/ci/openshift/fider-bcgov.bc.yaml
@@ -40,13 +40,14 @@ objects:
         git:
           uri: "${SOURCE_REPOSITORY_URL}"
           ref: "${SOURCE_REPOSITORY_REF}"
+        contextDir: fider
       strategy:
         type: Docker
         dockerStrategy:
           from:
             kind: DockerImage
             name: alpine:3.10
-          dockerfilePath: Dockerfile.openshift
+          dockerfilePath: ../Dockerfile.openshift
       output:
         to:
           kind: ImageStreamTag

--- a/ci/openshift/fider-bcgov.bc.yaml
+++ b/ci/openshift/fider-bcgov.bc.yaml
@@ -18,8 +18,7 @@ parameters:
     value: https://github.com/garywong-bc/nrm-feedback
   - name: SOURCE_REPOSITORY_REF
     required: true
-    # value: master
-    value: feature/upgrade-fider-to-v19.1
+    value: master
 objects:
   - kind: ImageStream
     apiVersion: v1
@@ -53,8 +52,8 @@ objects:
           name: "${NAME}:${VERSION}"
       resources:
         limits:
-          cpu: 250m
-          memory: 2048Mi
+          cpu: 500m
+          memory: 4096Mi
         requests:
-          cpu: 100m
-          memory: 1024Mi
+          cpu: 200m
+          memory: 2048Mi

--- a/ci/openshift/fider-bcgov.bc.yaml
+++ b/ci/openshift/fider-bcgov.bc.yaml
@@ -5,55 +5,56 @@ message: A new Fider Image, customized with noTLS, has been created in your proj
 metadata:
   name: nrm-feedback-bc
 parameters:
-- name: NAME
-  displayName: Name
-  description: A descriptive name of the image
-  value: fider-bcgov
-  required: true
-- name: VERSION
-  required: true
-  value: latest
-- name: SOURCE_REPOSITORY_URL
-  required: true
-  value: https://github.com/garywong-bc/nrm-feedback
-- name: SOURCE_REPOSITORY_REF
-  required: true
-  value: master
+  - name: NAME
+    displayName: Name
+    description: A descriptive name of the image
+    value: fider-bcgov
+    required: true
+  - name: VERSION
+    required: true
+    value: latest
+  - name: SOURCE_REPOSITORY_URL
+    required: true
+    value: https://github.com/garywong-bc/nrm-feedback
+  - name: SOURCE_REPOSITORY_REF
+    required: true
+    # value: master
+    value: feature/upgrade-fider-to-v19.1
 objects:
-- kind: ImageStream
-  apiVersion: v1
-  metadata:
-    labels:
-      build: nrm-feedback
-    name: ${NAME}
-- kind: BuildConfig
-  apiVersion: build.openshift.io/v1
-  metadata:
-    name: nrm-feedback
-    labels:
-      build: nrm-feedback
-  spec:
-    runPolicy: Serial
-    source:
-      type: Git
-      git:
-        uri: "${SOURCE_REPOSITORY_URL}"
-        ref: "${SOURCE_REPOSITORY_REF}"
-    strategy:
-      type: Docker
-      dockerStrategy:
-        from:
-          kind: DockerImage
-          name: alpine:3.10
-        dockerfilePath: Dockerfile.openshift
-    output:
-      to:
-        kind: ImageStreamTag
-        name: "${NAME}:${VERSION}"
-    resources:
-      limits:
-        cpu: 250m
-        memory: 2048Mi
-      requests:
-        cpu: 100m
-        memory: 1024Mi
+  - kind: ImageStream
+    apiVersion: v1
+    metadata:
+      labels:
+        build: nrm-feedback
+      name: ${NAME}
+  - kind: BuildConfig
+    apiVersion: build.openshift.io/v1
+    metadata:
+      name: nrm-feedback
+      labels:
+        build: nrm-feedback
+    spec:
+      runPolicy: Serial
+      source:
+        type: Git
+        git:
+          uri: "${SOURCE_REPOSITORY_URL}"
+          ref: "${SOURCE_REPOSITORY_REF}"
+      strategy:
+        type: Docker
+        dockerStrategy:
+          from:
+            kind: DockerImage
+            name: alpine:3.10
+          dockerfilePath: Dockerfile.openshift
+      output:
+        to:
+          kind: ImageStreamTag
+          name: "${NAME}:${VERSION}"
+      resources:
+        limits:
+          cpu: 250m
+          memory: 2048Mi
+        requests:
+          cpu: 100m
+          memory: 1024Mi

--- a/ci/openshift/fider-bcgov.bc.yaml
+++ b/ci/openshift/fider-bcgov.bc.yaml
@@ -47,7 +47,7 @@ objects:
           from:
             kind: DockerImage
             name: alpine:3.10
-          dockerfilePath: Dockerfile.openshift
+          dockerfilePath: "../Dockerfile.openshift"
       output:
         to:
           kind: ImageStreamTag

--- a/ci/openshift/fider-bcgov.bc.yaml
+++ b/ci/openshift/fider-bcgov.bc.yaml
@@ -45,7 +45,7 @@ objects:
         dockerStrategy:
           from:
             kind: DockerImage
-            name: alpine:3.10
+            name: debian:buster-slim
           dockerfilePath: Dockerfile.openshift
       output:
         to:

--- a/ci/openshift/fider-bcgov.bc.yaml
+++ b/ci/openshift/fider-bcgov.bc.yaml
@@ -40,14 +40,13 @@ objects:
         git:
           uri: "${SOURCE_REPOSITORY_URL}"
           ref: "${SOURCE_REPOSITORY_REF}"
-        contextDir: fider
       strategy:
         type: Docker
         dockerStrategy:
           from:
             kind: DockerImage
             name: alpine:3.10
-          dockerfilePath: "../Dockerfile.openshift"
+          dockerfilePath: Dockerfile.openshift
       output:
         to:
           kind: ImageStreamTag

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,37 @@
-version: '3'
+version: "3"
+# To restart w/o datea in the DB Directory: rm -rf ./var/fider/pg_data/
 services:
   db:
     env_file:
-    - ./.env  
+      - ./.env
     restart: always
     image: postgres:9.6
     volumes:
-      - ./var/fider/pg_data:/var/lib/postgresql/data
+      - postgresql:/var/lib/postgresql/data:delegated
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
       interval: 10s
       timeout: 5s
       retries: 5
-      
+
+  # http://localhost:9999/signup?
   app:
     env_file:
-    - ./.env   
+      - ./.env
     restart: always
     build:
       context: ./fider
-      dockerfile: ../Dockerfile
+      dockerfile: ../Dockerfile.dev
+    entrypoint:
+      [
+        "/bin/sh",
+        "-c",
+        "dockerize -wait tcp://db:5432 -- ./fider migrate && ./fider",
+      ]
     ports:
       - "9999:3000"
     depends_on:
       - db
+
+volumes:
+  postgresql:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
-version: "3"
-# To restart w/o datea in the DB Directory: rm -rf ./var/fider/pg_data/
+version: "3.8"
+
 services:
   db:
     env_file:

--- a/sample.env
+++ b/sample.env
@@ -1,13 +1,16 @@
 GO_ENV=
 POSTGRES_USER=
 POSTGRES_PASSWORD=
-DATABASE_URL=
+HOST_DOMAIN=localhost
+DATABASE_URL=postgres://<>:<>@db:5432/<>?sslmode=disable
+# DATABASE_URL=postgresql://[user[:password]@][netloc][:port][/dbname][?param1=value1&...]
 # If testing NoTLS while NOT on BC Gov Network
-#EMAIL_MAILGUN_API=
-#EMAIL_MAILGUN_DOMAIN=
-#JWT_SECRET=
-#EMAIL_NOREPLY=
+EMAIL_SMTP_HOST=
+EMAIL_SMTP_PORT=
+EMAIL_SMTP_USERNAME=
+EMAIL_SMTP_PASSWORD=
+EMAIL_SMTP_ENABLE_STARTTLS=true
+JWT_SECRET=
+ # Can generate an RS256 working example, at https://jwt.io/
+EMAIL_NOREPLY=
 # Else.. testing out NoTLS,when on BC Gov Network
-#EMAIL_SMTP_HOST=
-#EMAIL_SMTP_PORT=
-#EMAIL_SMTP_USERNAME=


### PR DESCRIPTION
In summary:
- Update fider to v19.1, from v19.0
- Update `Dockerfile.openshift` from updated `./fider/Dockerfile` and again over-rode SMTPS on updated v19.1 Go code
- followed Fider move to debian from alpine

For local deploys:
- Update `Dockerfile.dev` from updated `./fider/Dockerfile`, and installed `dockerize`
- Enhance `docker-compose` to support `dockerize -wait` on DB readiness, and use anonymous volumes
- Update `sample.env` to better illustrate example values