### PR TITLE
Upgrade fider to v0.21.1

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,7 +1,7 @@
 #####################
 ### Server Build Step
 #####################
-FROM golang:1.16.6-buster AS server-builder 
+FROM golang:1.18 AS server-builder 
 
 ARG buildnumber=local
 
@@ -14,8 +14,9 @@ COPY fider .
 RUN sed -i -e '/auth :=/d' \
     -e 's/servername, smtpConfig.EnableStartTLS, auth, email/servername, false, nil, email/g' \
     -e 's/Config{ServerName: host}/Config{InsecureSkipVerify: true, ServerName: host}/g' \
-    app/services/email/smtp/smtp.go && \
-    BUILDNUMBER=${buildnumber} GOOS=linux GOARCH=amd64 make build-server
+    app/services/email/smtp/smtp.go
+
+RUN BUILDNUMBER=${buildnumber} GOOS=linux GOARCH=amd64 GOFLAGS="-buildvcs=false" make build-server
 
 #################
 ### UI Build Step
@@ -39,7 +40,7 @@ RUN make build-ui
 ################
 ### Runtime Step
 ################
-FROM debian:buster-slim
+FROM debian:stable-slim
 
 RUN apt-get update
 RUN apt-get install -y ca-certificates


### PR DESCRIPTION
Upgrade to latest fider version,  https://github.com/getfider/fider/commit/c9c55b2f5b33a76015241b97e03cfac1254b42a7

Fix build failures in current version (Go vesion issues) and Build settings that are requried for go v1.18 
